### PR TITLE
Optimize lcd driver

### DIFF
--- a/src/sim/lvgl-integration.c
+++ b/src/sim/lvgl-integration.c
@@ -16,10 +16,15 @@
 #include <time.h>
 
 #define BYTES_PER_PIXEL (LV_COLOR_FORMAT_GET_SIZE(LV_COLOR_FORMAT_RGB565))
-static uint8_t lvgl_buf[LCD_WIDTH * LCD_HEIGHT / 10 * BYTES_PER_PIXEL];
+static uint8_t lvgl_buf[LCD_WIDTH * (LCD_HEIGHT / 10) * BYTES_PER_PIXEL];
+static uint8_t pixel_buf[LCD_WIDTH * LCD_HEIGHT * 3];
+
+
+//static uint8_t fb[LV_HOR_RES_MAX * LV_VER_RES_MAX * 3];
 
 cairo_surface_t *lv_int_surface = NULL;
 GtkWidget *drawing_area = NULL;
+static GdkPixbuf    *pixbuf = NULL;
 
 extern void lv_demo_music();
 
@@ -97,6 +102,75 @@ static uint64_t get_timestamp_ms()
     return t;
 }
 
+// static void flush_cb(lv_display_t * display, const lv_area_t * area, uint8_t * px_map)
+// {
+//     #define PIXEL_SIZE 1
+//     CHECK_SURFACE();
+//     if (!drawing_area) { 
+//         lv_display_flush_ready(display);
+//         return;
+//     }
+//     cairo_t *cr = cairo_create (lv_int_surface);
+
+//     int x, y, ri, gi, bi;
+//     double r,g,b;
+//     uint16_t * color_p = (uint16_t *) px_map;
+//     for(y = area->y1; y <= area->y2; y++) {
+//         for(x = area->x1; x <= area->x2; x++) {
+//             // *color_p format (565): rrrrrGGGGGGbbbbb
+
+//             r = ((*color_p) >> 11) / (double) 0b00011111;
+//             g = (((*color_p) >> 5) & 0b00111111) / (double) 0b00111111;
+//             b = ((*color_p) & 0b00011111) / (double) 0b00011111;
+
+//             cairo_set_source_rgba (cr, r, g, b, 1);
+//             cairo_rectangle (cr, x, y, PIXEL_SIZE, PIXEL_SIZE);
+//             cairo_fill (cr);
+//             color_p++;
+//         }
+//     }
+//     gtk_widget_queue_draw_area (drawing_area, 0, 0, LCD_WIDTH, LCD_HEIGHT);
+
+//     cairo_destroy (cr);
+//     lv_display_flush_ready(display);
+
+// }
+
+//static void flush_cb(lv_display_t * display, const lv_area_t * area, uint8_t * px_map)
+//static void flush_cb(lv_disp_drv_t * disp_drv, const lv_area_t * area, lv_color_t * color_p)
+// static void __flush_cb(lv_display_t * disp_drv, const lv_area_t * area, lv_color_t * color_p)
+// {
+//     lv_coord_t hres = disp_drv->rotated == 0 ? disp_drv->hor_res : disp_drv->ver_res;
+//     lv_coord_t vres = disp_drv->rotated == 0 ? disp_drv->ver_res : disp_drv->hor_res;
+
+
+//     /*Return if the area is out the screen*/
+//     if(area->x2 < 0 || area->y2 < 0 || area->x1 > hres - 1 || area->y1 > vres - 1) {
+
+//         lv_disp_flush_ready(disp_drv);
+//         return;
+//     }
+
+//     int32_t y;
+//     int32_t x;
+//     int32_t p;
+//     for(y = area->y1; y <= area->y2 && y < disp_drv->ver_res; y++) {
+//         p = (y * disp_drv->hor_res + area->x1) * 3;
+//         for(x = area->x1; x <= area->x2 && x < disp_drv->hor_res; x++) {
+//             fb[p] = color_p->ch.red;
+//             fb[p + 1] = color_p->ch.green;
+//             fb[p + 2] = color_p->ch.blue;
+
+//             p += 3;
+//             color_p ++;
+//         }
+//     }
+
+//     /*IMPORTANT! It must be called to tell the system the flush is ready*/
+//     lv_disp_flush_ready(disp_drv);
+
+// }
+
 static void flush_cb(lv_display_t * display, const lv_area_t * area, uint8_t * px_map)
 {
     #define PIXEL_SIZE 1
@@ -105,28 +179,88 @@ static void flush_cb(lv_display_t * display, const lv_area_t * area, uint8_t * p
         lv_display_flush_ready(display);
         return;
     }
-    cairo_t *cr = cairo_create (lv_int_surface);
-
-    int x, y, ri, gi, bi;
-    double r,g,b;
     uint16_t * color_p = (uint16_t *) px_map;
+    // cairo_t *cr = cairo_create (lv_int_surface);
+
+
+    // int x, y, ri, gi, bi;
+    // double r,g,b;
+    // uint16_t * color_p = (uint16_t *) px_map;
+    // for(y = area->y1; y <= area->y2; y++) {
+    //     for(x = area->x1; x <= area->x2; x++) {
+    //         // *color_p format (565): rrrrrGGGGGGbbbbb
+
+    //         r = ((*color_p) >> 11) / (double) 0b00011111;
+    //         g = (((*color_p) >> 5) & 0b00111111) / (double) 0b00111111;
+    //         b = ((*color_p) & 0b00011111) / (double) 0b00011111;
+
+    //         cairo_set_source_rgba (cr, r, g, b, 1);
+    //         cairo_rectangle (cr, x, y, PIXEL_SIZE, PIXEL_SIZE);
+    //         cairo_fill (cr);
+    //         color_p++;
+    //     }
+    // }
+    // gtk_widget_queue_draw_area (drawing_area, 0, 0, LCD_WIDTH, LCD_HEIGHT);
+
+    // cairo_destroy (cr);
+
+    int32_t y;
+    int32_t x;
+    int32_t p;
     for(y = area->y1; y <= area->y2; y++) {
+    //for(y = area->y1; y <= area->y2 && y < disp_drv->ver_res; y++) {
+        p = (y * LCD_WIDTH + area->x1) * 3;
+        //for(x = area->x1; x <= area->x2 && x < disp_drv->hor_res; x++) {
         for(x = area->x1; x <= area->x2; x++) {
+            // lvgl_buf[p] = ((*color_p) >> 11) & 0b00011111; //color_p->ch.red;
+            // lvgl_buf[p + 1] = (((*color_p) >> 5) & 0b00111111); //color_p->ch.green;
+            // lvgl_buf[p + 2] = ((*color_p) & 0b00011111); //color_p->ch.blue;
+
             // *color_p format (565): rrrrrGGGGGGbbbbb
+            pixel_buf[p] = (*color_p >> 8) & 0b0000000011111000; //color_p->ch.red;
+            pixel_buf[p + 1] = (*color_p >> 3) & 0b0000000011111100; //color_p->ch.green;
+            pixel_buf[p + 2] = (*color_p << 3) & 0b0000000011111000;  //color_p->ch.blue;
 
-            r = ((*color_p) >> 11) / (double) 0b00011111;
-            g = (((*color_p) >> 5) & 0b00111111) / (double) 0b00111111;
-            b = ((*color_p) & 0b00011111) / (double) 0b00011111;
-
-            cairo_set_source_rgba (cr, r, g, b, 1);
-            cairo_rectangle (cr, x, y, PIXEL_SIZE, PIXEL_SIZE);
-            cairo_fill (cr);
+            p += 3;
             color_p++;
         }
     }
+
+    //memset(pixel_buf, 0x80, sizeof(pixel_buf));
+    if (drawing_area /* && lv_int_surface */) {
+        //gtk_image_set_from_pixbuf ((GtkImage *) drawing_area, pixbuf);
+
+
+        pixbuf = gdk_pixbuf_new_from_data(  (guchar*)pixel_buf, 
+                                            GDK_COLORSPACE_RGB, 
+                                            false, 
+                                            8, 
+                                            LCD_WIDTH, 
+                                            LCD_HEIGHT, 
+                                            LCD_WIDTH * 3, 
+                                            NULL, 
+                                            NULL);
+        if (!pixbuf) {
+            LOG_E("Could not create pixbuf for display\n");
+            return;
+        }
+
+        // lv_int_surface = gdk_cairo_surface_create_from_pixbuf (
+        //     pixbuf,
+        //     0,
+        //     GdkWindow* for_window);
+
+
+        cairo_t *cr = cairo_create (lv_int_surface);
+        gdk_cairo_set_source_pixbuf(cr, pixbuf, 0, 0);
+        //cairo_set_source_rgba(cr, 1.0, 1.0, 1.0, 1.0);
+        cairo_paint(cr);
+        // cairo_destroy (cr);
+        // gdk_pixbuf_unref(pixbuf);
+        // pixbuf = NULL;
+    }
     gtk_widget_queue_draw_area (drawing_area, 0, 0, LCD_WIDTH, LCD_HEIGHT);
 
-    cairo_destroy (cr);
     lv_display_flush_ready(display);
 
 }
@@ -154,14 +288,13 @@ void lv_int_init()
 {
     lv_init();
 
-    //lv_tick_set_cb((lv_tick_get_cb_t) get_timestamp_ms);
     lvgl_display = lv_display_create(LCD_WIDTH, LCD_HEIGHT);
 
     lv_display_set_buffers( lvgl_display, 
                             lvgl_buf, 
                             NULL, 
                             sizeof(lvgl_buf),
-                            LV_DISPLAY_RENDER_MODE_PARTIAL);
+                            LV_DISPLAY_RENDER_MODE_FULL);
                             
     lv_display_set_flush_cb(lvgl_display, flush_cb);
 

--- a/src/sim/lvgl-integration.c
+++ b/src/sim/lvgl-integration.c
@@ -16,11 +16,8 @@
 #include <time.h>
 
 #define BYTES_PER_PIXEL (LV_COLOR_FORMAT_GET_SIZE(LV_COLOR_FORMAT_RGB565))
-static uint8_t lvgl_buf[LCD_WIDTH * (LCD_HEIGHT / 10) * BYTES_PER_PIXEL];
+static uint8_t lvgl_buf[LCD_WIDTH * LCD_HEIGHT * BYTES_PER_PIXEL];
 static uint8_t pixel_buf[LCD_WIDTH * LCD_HEIGHT * 3];
-
-
-//static uint8_t fb[LV_HOR_RES_MAX * LV_VER_RES_MAX * 3];
 
 cairo_surface_t *lv_int_surface = NULL;
 GtkWidget *drawing_area = NULL;
@@ -208,25 +205,19 @@ static void flush_cb(lv_display_t * display, const lv_area_t * area, uint8_t * p
     int32_t x;
     int32_t p;
     for(y = area->y1; y <= area->y2; y++) {
-    //for(y = area->y1; y <= area->y2 && y < disp_drv->ver_res; y++) {
         p = (y * LCD_WIDTH + area->x1) * 3;
-        //for(x = area->x1; x <= area->x2 && x < disp_drv->hor_res; x++) {
         for(x = area->x1; x <= area->x2; x++) {
-            // lvgl_buf[p] = ((*color_p) >> 11) & 0b00011111; //color_p->ch.red;
-            // lvgl_buf[p + 1] = (((*color_p) >> 5) & 0b00111111); //color_p->ch.green;
-            // lvgl_buf[p + 2] = ((*color_p) & 0b00011111); //color_p->ch.blue;
 
             // *color_p format (565): rrrrrGGGGGGbbbbb
-            pixel_buf[p] = (*color_p >> 8) & 0b0000000011111000; //color_p->ch.red;
-            pixel_buf[p + 1] = (*color_p >> 3) & 0b0000000011111100; //color_p->ch.green;
-            pixel_buf[p + 2] = (*color_p << 3) & 0b0000000011111000;  //color_p->ch.blue;
+            pixel_buf[p] = (*color_p >> 8) & 0b11111000;
+            pixel_buf[p + 1] = (*color_p >> 3) & 0b11111100;
+            pixel_buf[p + 2] = (*color_p << 3) & 0b11111000;
 
             p += 3;
             color_p++;
         }
     }
 
-    //memset(pixel_buf, 0x80, sizeof(pixel_buf));
     if (drawing_area /* && lv_int_surface */) {
         //gtk_image_set_from_pixbuf ((GtkImage *) drawing_area, pixbuf);
 
@@ -245,15 +236,8 @@ static void flush_cb(lv_display_t * display, const lv_area_t * area, uint8_t * p
             return;
         }
 
-        // lv_int_surface = gdk_cairo_surface_create_from_pixbuf (
-        //     pixbuf,
-        //     0,
-        //     GdkWindow* for_window);
-
-
         cairo_t *cr = cairo_create (lv_int_surface);
         gdk_cairo_set_source_pixbuf(cr, pixbuf, 0, 0);
-        //cairo_set_source_rgba(cr, 1.0, 1.0, 1.0, 1.0);
         cairo_paint(cr);
         // cairo_destroy (cr);
         // gdk_pixbuf_unref(pixbuf);

--- a/src/sim/lvgl-sim.c
+++ b/src/sim/lvgl-sim.c
@@ -232,7 +232,7 @@ static gboolean on_gpio_win_delete(GtkWidget *widget, GdkEvent *event, gpointer 
     gtk_widget_hide(widget);
     return TRUE;
 }
-
+static     GtkApplicationWindow *app_win = NULL;
 static void cb_application_activate (GtkApplication* app, gpointer user_data)
 {
     GtkBuilder* builder = gtk_builder_new ();
@@ -251,14 +251,14 @@ static void cb_application_activate (GtkApplication* app, gpointer user_data)
     gpio_win = GTK_WINDOW (gtk_builder_get_object (builder, "id_gpio_dialog"));
     about_win = GTK_WINDOW (gtk_builder_get_object (builder, "id_about_dialog"));
 
-    GtkApplicationWindow *window = GTK_APPLICATION_WINDOW (gtk_builder_get_object (builder, "application_window"));
-    g_warn_if_fail (window != NULL);
-    g_object_set (window, "application", app, NULL);
-    gtk_window_set_title (GTK_WINDOW (window), "LVGL Simulator");
+    app_win = GTK_APPLICATION_WINDOW (gtk_builder_get_object (builder, "application_window"));
+    g_warn_if_fail (app_win != NULL);
+    g_object_set (app_win, "application", app, NULL);
+    gtk_window_set_title (GTK_WINDOW (app_win), "LVGL Simulator");
 
     GdkPixbuf * icon = gdk_pixbuf_new_from_resource (APP_PREFIX "/lvgl_icon.png", &error);
     if (icon) {
-        gtk_window_set_icon(GTK_WINDOW(window), icon);
+        gtk_window_set_icon(GTK_WINDOW(app_win), icon);
     }
     else {
         LOG_E("Could not load icon\n");
@@ -275,7 +275,7 @@ static void cb_application_activate (GtkApplication* app, gpointer user_data)
     leds[2] = gtk_builder_get_object (builder, "id_led_3");
     leds[3] = gtk_builder_get_object (builder, "id_led_4");
 
-    g_signal_connect (window, "destroy", G_CALLBACK (cb_window_destory), NULL);
+    g_signal_connect (app_win, "destroy", G_CALLBACK (cb_window_destory), NULL);
 
     {
         drawing_area = GTK_WIDGET (gtk_builder_get_object (builder, "drawing_area"));
@@ -297,11 +297,11 @@ static void cb_application_activate (GtkApplication* app, gpointer user_data)
 
     gtk_builder_connect_signals(builder,NULL);
 
-    gtk_widget_show_all (GTK_WIDGET (window));
+    gtk_widget_show_all (GTK_WIDGET (app_win));
 
 
     if (gpio_win) {
-        set_windows_positions(window, gpio_win);
+        set_windows_positions(app_win, gpio_win);
         g_signal_connect(G_OBJECT(gpio_win), 
             "delete-event", G_CALLBACK(on_gpio_win_delete), NULL);
 
@@ -326,7 +326,7 @@ static void cb_application_activate (GtkApplication* app, gpointer user_data)
             "delete-event", G_CALLBACK(on_about_win_delete), NULL);
     }
 
-    g_timeout_add(LVGL_PERIOD_TIME, (GSourceFunc) time_handler, (gpointer) window);
+    g_timeout_add(LVGL_PERIOD_TIME, (GSourceFunc) time_handler, (gpointer) app_win);
     g_object_unref (builder);
 }
 


### PR DESCRIPTION
Cairo pixel manipulation is very slow using cairo_set_source_rgba and cairo_rectangle. 
So lets use GdkPixbuf instead.